### PR TITLE
Idiomatic lazy httphandler

### DIFF
--- a/samples/AuthExample/Domain.fs
+++ b/samples/AuthExample/Domain.fs
@@ -44,8 +44,8 @@ let updateUser (storage : IStorage) (id : string) (userDto : UserDto) =
         users
         |> Seq.tryFind (fun user -> user.Id = id)
         |> function
-            | Some user -> Result.Ok user
-            | None      -> Result.Error { Code = "123"; Message = "User to update not found!" }
+            | Some user -> Ok user
+            | None      -> Error { Code = "123"; Message = "User to update not found!" }
     storage.GetAll()
     |> Result.bind checkUserExist
     |> Result.bind (fun _ -> storage.Update id userDto)
@@ -55,8 +55,8 @@ let deleteUser (storage : IStorage) (id : string) =
         users
         |> Seq.tryFind (fun user -> user.Id = id)
         |> function
-            | Some user -> Result.Ok user
-            | None      -> Result.Error { Code = "456"; Message = "User to delete not found!" }
+            | Some user -> Ok user
+            | None      -> Error { Code = "456"; Message = "User to delete not found!" }
     storage.GetAll()
     |> Result.bind checkUserExist
     |> Result.bind (fun _ -> storage.Remove id)

--- a/samples/AuthExample/Handler.fs
+++ b/samples/AuthExample/Handler.fs
@@ -52,8 +52,7 @@ let handleCreateUser : HttpHandler =
         (fun _ -> handleBadRequest)
 
 let handleReadUsers : HttpHandler =
-    Request.mapRoute
-        (ignore)
+    Request.handle
         (fun _ -> 
             getAllUsersWithStorage ()
             |> handleResult)
@@ -63,8 +62,8 @@ let handleUpdateUser : HttpHandler =
         (fun routeCollection -> 
             routeCollection.TryGetString "id"
             |> function 
-                | Some id -> Result.Ok id
-                | None    -> Result.Error "No user id provided")
+                | Some id -> Ok id
+                | None    -> Error "No user id provided")
         (fun id ->
             Request.bindJson
                 (fun (userDto : UserDto) -> 
@@ -78,8 +77,8 @@ let handleDeleteUser : HttpHandler =
         (fun routeCollection -> 
             routeCollection.TryGetString "id"
             |> function 
-                | Some id -> Result.Ok id
-                | None    -> Result.Error "No user id provided")
+                | Some id -> Ok id
+                | None    -> Error "No user id provided")
         (fun id ->
             deleteUserWithStorage id
             |> handleResult)

--- a/samples/AuthExample/Repository.fs
+++ b/samples/AuthExample/Repository.fs
@@ -10,17 +10,17 @@ type MemoryStorage() =
     ]
     interface IStorage with
         member _.GetAll() = 
-            values |> Seq.map id |> Result.Ok
+            values |> Seq.map id |> Ok
         member _.Add(id : string) (userDto : UserDto) = 
             let user = { Id = id; Username = userDto.Username; Name = userDto.Name; Surname = userDto.Surname }
             values <- List.append values [user]
-            Result.Ok user
+            Ok user
         member _.Update(id: string) (userDto: UserDto) = 
             let user = { Id = id; Username = userDto.Username; Name = userDto.Name; Surname = userDto.Surname }
             values <- values |> List.map (fun u -> if u.Id = id then user else u)
-            Result.Ok user
+            Ok user
         member _.Remove(id: string) = 
             let user = values |> List.find (fun u -> u.Id = id)
             values <- values |> List.filter (fun u -> u.Id <> id)
-            Result.Ok user
+            Ok user
 

--- a/src/Falco/Request.fs
+++ b/src/Falco/Request.fs
@@ -166,7 +166,6 @@ let bindForm
         return! respondWith ctx
     }
 
-
 /// Validate the CSRF of the current request
 let validateCsrfToken
     (handleOk : HttpHandler)
@@ -193,6 +192,11 @@ let bindFormSecure
     validateCsrfToken
         (bindForm binder handleOk handleError)
         handleInvalidToken
+
+/// Create an HttpHandler with lazy evaluation
+let handle
+    (handle : unit -> HttpHandler) : HttpHandler =
+    fun ctx -> handle () ctx
 
 /// Project RouteCollectionReader onto 'a and provide
 /// to next HttpHandler


### PR DESCRIPTION
Hi @pimbrouwers , how is it going? :)

I'm toying around Falco these days, I've added a new very simple function `Request.handle` which I think could be useful in some scenarios!

Let's take for example the function `handleReadUsers` in the previous version of AuthExample.Handler.fs

``` fsharp
let handleReadUsers : HttpHandler =
    Request.mapRoute
        (ignore)
        (fun _ -> 
            getAllUsersWithStorage ()
            |> handleResult)
```
For sake of completion, let's show the utility methods

``` fsharp
let handleError error : HttpHandler =
    Response.withStatusCode 400 
    >> Response.ofJson error

let handleResult = function
    | Result.Ok result   -> Response.ofJson result
    | Result.Error error -> handleError error
```

One could argue that it could be rewritten in this way:

``` fsharp
let handleReadUsers : HttpHandler =
    getAllUsersWithStorage () |> handleResult
```

The problem with this function is that it immediately retrieves the users from the storage (e.g. a database) and the result is cached in the response.

In order to defer the execution and reevaluates the `getAllUsersWithStorage` function,  I exploit the `Request.mapRoute` with the `ignore` on the map function. But I feel it's more a trick.

That's why I thought about a simple helper function to do this.

``` fsharp
let handleReadUsers : HttpHandler =
    Request.handle
        (fun _ -> 
            getAllUsersWithStorage ()
            |> handleResult)
```

I know I could do in the following way 

``` fsharp
let handleReadUsers : HttpHandler =
    fun ctx -> 
        let users = getAllUsersWithStorage ()
        handleResult users ctx
```

but I think this new function is more idiomatic, let me know what you think, if I have to specify some docs, some tests, etc ;)
