### PR TITLE
Fixed Change-status endpoint/controller in Todo Sample

### DIFF
--- a/samples/Todo/Common.fs
+++ b/samples/Todo/Common.fs
@@ -4,6 +4,6 @@
 module Urls = 
     let ``/`` = "/"
     let ``/todo/create`` = "/todo/create"
-    let ``/todo/complete/{id}`` = sprintf "/todo/complete/%s"
-    let ``/todo/incomplete/{id}`` = sprintf "/todo/incomplete/%s"
+    let ``/todo/complete/{id}`` = sprintf "/todo/change-status?id=%s&complete=true"
+    let ``/todo/incomplete/{id}`` = sprintf "/todo/change-status?id=%s&complete=false"
 

--- a/samples/Todo/Program.fs
+++ b/samples/Todo/Program.fs
@@ -40,6 +40,8 @@ let main args =
                         GET, Todo.Controller.create
                         POST, Todo.Controller.createSubmit
                     ]
+                get "/todo/change-status"
+                    Todo.Controller.changeStatusSubmit
                 get "/" 
                     Todo.Controller.index
             ]


### PR DESCRIPTION
Hi,
I was studying the samples to get the deepest understanding of this library and I saw the **Todo sample** was missing some features.

I'm still learning so I don't expect my commits to be merge ready, so feel free to criticize.

As title says, I've only linked endpoint/controller to the Model/View code that was already there.
There a couple of points I am unsure about:

- `/todo/change-status` endpoint is mapped as a GET http message.
    I saw in commits history that the `todos` in `View.Index` had a form inside each one. I presume it was used to send a POST http message.
    Since the form has been replaced by a button, from what I understood now it's impossible to send a POST request from the button itself.
- I moved `{id}` from URL address to query parameter,  this way todo data is collected from query parameters only.
- In `Controller.changeStatusSubmit` controller I had to make an explicit call to `Provider.TodoProvider.getAll`.
    I don't like this one bit, but found no other easy options.
- Sill in `Controller.changeStatusSubmit` I used `Request.mapQuery` and not `Request.bindQuery` because the links (with relative query data) are constructed by the program, so I supposed no validation is needed. Also data get validated right after that, inside `ChangeStatus.handle`.
    Furthermore, since I was copying from `Controller.createSubmit` controller, I would have use something like `Request.mapQuerySecure` but found none. I'm quite sure the problem here is that I don't know perfectly what am I doing, so this missing it's probably correct.

Thanks for your time.
I hope this code could be useful.