### PR TITLE
Embed PDBs in the library so that sourcelink and symbols are present …

### DIFF
--- a/src/Falco/Falco.fsproj
+++ b/src/Falco/Falco.fsproj
@@ -11,7 +11,7 @@
         
     <!-- Build config -->
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <DebugType>portable</DebugType>
+    <DebugType>embedded</DebugType>
     <OutputType>Library</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>


### PR DESCRIPTION
…for users

If you keep `portable`, then you have to manually include the PDB in the nuget package or else users don't get sourcelink info.

Also the sourcelink docs suggest embedded for most OSS projects for this reason.