### PR TITLE
Update Response.fs

### DIFF
--- a/src/Falco/Response.fs
+++ b/src/Falco/Response.fs
@@ -158,7 +158,6 @@ let ofJsonOptions (options : JsonSerializerOptions) (obj : 'a) : HttpHandler =
         #endif
             use str = new MemoryStream()
             do! JsonSerializer.SerializeAsync(str, obj, options = options)
-            str.Flush ()
             let bytes = str.ToArray ()
             let byteLen = bytes.Length
             ctx.Response.ContentLength <- Nullable<int64>(byteLen |> int64)


### PR DESCRIPTION
Removed due to not doing anything https://docs.microsoft.com/en-us/dotnet/api/system.io.memorystream.flush?view=net-6.0

In relation to #65