### PR TITLE
Fix async handler not awaited before continuing + add non-regression test

### DIFF
--- a/src/Falco/Core.fs
+++ b/src/Falco/Core.fs
@@ -1,8 +1,12 @@
-﻿namespace Falco
+namespace Falco
 
 open System
 open System.Threading.Tasks
 open Microsoft.AspNetCore.Http
+open System.Runtime.CompilerServices
+
+[<assembly: InternalsVisibleTo("Falco.Tests")>]
+do ()
 
 /// The eventual return of asynchronous HttpContext processing.
 type HttpHandler = HttpContext -> Task

--- a/src/Falco/Request.fs
+++ b/src/Falco/Request.fs
@@ -16,12 +16,12 @@ let private httpPipe
     (next : 'T -> HttpHandler) : HttpHandler = fun ctx ->
     next (prepare ctx) ctx
 
-let private httpPipeTask
+let internal httpPipeTask
     (prepare :  HttpContext -> Task<'T>)
     (next : 'T -> HttpHandler) : HttpHandler = fun ctx ->
     task {
         let! x = prepare ctx
-        return next x ctx
+        return! next x ctx
     }
 
 /// Obtain the HttpVerb of the request


### PR DESCRIPTION
Fixes #94 

It's clearer to see the problem when rewriting the `httpPipeTask` returned function to make it an explicit function:
![image](https://user-images.githubusercontent.com/1535823/205440541-a847c6b7-f7c0-4c2e-84dc-00b4a430c7e8.png)

The return type is inferred as `Task<Task>` when it should be just a `Task`.
Nasty bug if you ask me. It's unfortunate in this situation that a `Task<Task>` is silently inferred into a `Task` and made compatible with `HttpHandler`...