### PR TITLE
Fix typos and standardize xml documentation style

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Thank you for considering contributing to Falco, and to those who have already c
 We kindly ask that before submitting a pull request, you first submit an [issue](https://github.com/pimbrouwers/Falco/issues) or open a [discussion](https://github.com/pimbrouwers/Falco/discussions).
 
 
-If functionality is added to the API, or changed, please kindly update the relevent [document](https://github.com/pimbrouwers/Falco/tree/master/docs). Unit tests must also be added and/or updated before a pull request can be successfully merged.
+If functionality is added to the API, or changed, please kindly update the relevant [document](https://github.com/pimbrouwers/Falco/tree/master/docs). Unit tests must also be added and/or updated before a pull request can be successfully merged.
 
 All pull requests should originate from the `develop` branch. A merge into this branch means that your changes are scheduled to go into production with the very next release, which could happen any time from the same day up to a couple weeks (depending on priorities and urgency).
 

--- a/samples/HelloWorld/Program.fs
+++ b/samples/HelloWorld/Program.fs
@@ -35,6 +35,9 @@ let handleGreet : HttpHandler = fun ctx ->
 [<EntryPoint>]
 let main args =
     webHost args {
+
+        use_static_files
+
         endpoints [
             get "/" handlePlainText
             get "/json" handleJson

--- a/src/Falco/ConfigBuilder.fs
+++ b/src/Falco/ConfigBuilder.fs
@@ -1,4 +1,4 @@
-﻿namespace Falco.HostBuilder
+namespace Falco.HostBuilder
 
 open System.IO
 open Microsoft.Extensions.Configuration
@@ -22,7 +22,7 @@ type ConfigBuilderSpec =
           OptionalFiles = []
           InMemory      = Map.empty }
 
-/// Computation expression to allow for elegant IConfiguration construction
+/// Computation expression to allow for elegant IConfiguration construction.
 type ConfigBuilder (args : string[]) =
     member _.Yield(_) = ConfigBuilderSpec.Empty
 
@@ -53,17 +53,17 @@ type ConfigBuilder (args : string[]) =
 
         bldr.Build() :> IConfiguration
 
-    /// Set the base path of the ConfigurationBuilder.
+    /// Sets the base path of the ConfigurationBuilder.
     [<CustomOperation("base_path")>]
     member _.SetBasePath (conf : ConfigBuilderSpec, basePath : string) =
         { conf with BasePath = basePath }
 
-    /// Add Environment Variables to the ConfigurationBuilder.
+    /// Adds Environment Variables to the ConfigurationBuilder.
     [<CustomOperation("add_env")>]
     member _.AddEnvVars (conf : ConfigBuilderSpec) =
         { conf with AddEnvVars = true }
 
-    /// Add an in-memory collection to the ConfigurationBuilder.
+    /// Adds an in-memory collection to the ConfigurationBuilder.
     ///
     /// Note: This is operation replaces the existing In Memory Collection.
     [<CustomOperation("in_memory")>]
@@ -71,37 +71,37 @@ type ConfigBuilder (args : string[]) =
         let inMemory = Map.ofSeq pairs
         { conf with InMemory = inMemory }
 
-    /// Add required config INI file to the ConfigurationBuilder.
+    /// Adds required config INI file to the ConfigurationBuilder.
     [<CustomOperation("required_ini")>]
     member _.AddRequiredIniFile (conf : ConfigBuilderSpec, filePath : string) =
         { conf with RequiredFiles = (IniFile filePath) :: conf.RequiredFiles }
 
-    /// Add optional config INI file to the ConfigurationBuilder.
+    /// Adds optional config INI file to the ConfigurationBuilder.
     [<CustomOperation("optional_ini")>]
     member _.AddOptionalIniFile (conf : ConfigBuilderSpec, filePath : string) =
         { conf with OptionalFiles = (IniFile filePath) :: conf.OptionalFiles }
 
-    /// Add required config XML file to the ConfigurationBuilder.
+    /// Adds required config XML file to the ConfigurationBuilder.
     [<CustomOperation("required_xml")>]
     member _.AddRequiredXmlFile (conf : ConfigBuilderSpec, filePath : string) =
         { conf with RequiredFiles = (XmlFile filePath) :: conf.RequiredFiles }
 
-    /// Add optional config XML file to the ConfigurationBuilder.
+    /// Adds optional config XML file to the ConfigurationBuilder.
     [<CustomOperation("optional_xml")>]
     member _.AddOptionalXmlFile (conf : ConfigBuilderSpec, filePath : string) =
         { conf with OptionalFiles = (XmlFile filePath) :: conf.OptionalFiles }
 
-    /// Add required config JSON file to the ConfigurationBuilder.
+    /// Adds required config JSON file to the ConfigurationBuilder.
     [<CustomOperation("required_json")>]
     member _.AddRequiredJsonFile (conf : ConfigBuilderSpec, filePath : string) =
         { conf with RequiredFiles = (JsonFile filePath) :: conf.RequiredFiles }
 
-    /// Add optional config JSON file to the ConfigurationBuilder.
+    /// Adds optional config JSON file to the ConfigurationBuilder.
     [<CustomOperation("optional_json")>]
     member _.AddOptionalJsonFile (conf : ConfigBuilderSpec, filePath : string) =
         { conf with OptionalFiles = (JsonFile filePath) :: conf.OptionalFiles }
 
 [<AutoOpen>]
 module ConfigurationBuilder =
-    /// Computation expression to allow for elegant IConfiguration construction
+    /// Computation expression to allow for elegant IConfiguration construction.
     let configuration args = ConfigBuilder(args)

--- a/src/Falco/Extensions.fs
+++ b/src/Falco/Extensions.fs
@@ -1,4 +1,4 @@
-﻿namespace Falco
+namespace Falco
 
 open System
 open Microsoft.AspNetCore.Builder
@@ -48,33 +48,33 @@ type internal FalcoEndpointDatasource(httpEndpoints : HttpEndpoint list) =
 [<AutoOpen>]
 module Extensions =
     type HttpContext with
-        /// Attempt to obtain depedency from IServiceCollection
+        /// Attempts to obtain dependency from IServiceCollection
         /// Throws InvalidDependencyException on null.
         member x.GetService<'T>() =
             x.RequestServices.GetRequiredService<'T>()
 
-        /// Obtain a named instance of ILogger.
+        /// Obtains a named instance of ILogger.
         member x.GetLogger (name : string) =
             let loggerFactory = x.GetService<ILoggerFactory>()
             loggerFactory.CreateLogger name
 
     type IEndpointRouteBuilder with
-        /// Activate Falco Endpoint integration
+        /// Activates Falco Endpoint integration.
         member x.UseFalcoEndpoints (endpoints : HttpEndpoint list) =
             let dataSource = FalcoEndpointDatasource(endpoints)
             x.DataSources.Add(dataSource)
 
     type IApplicationBuilder with
-        /// Determine if the application is running in development mode
+        /// Determines if the application is running in development mode.
         member x.IsDevelopment() =
             x.ApplicationServices.GetService<IWebHostEnvironment>().IsDevelopment()
 
-        /// Activate Falco integration with IEndpointRouteBuilder
+        /// Activates Falco integration with IEndpointRouteBuilder.
         member x.UseFalco (endpoints : HttpEndpoint list) =
             x.UseRouting()
              .UseEndpoints(fun r -> r.UseFalcoEndpoints(endpoints))
 
-        /// Register a Falco HttpHandler as exception handler lambda.
+        /// Registers a Falco HttpHandler as exception handler lambda.
         /// See: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/error-handling?#exception-handler-lambda
         member x.UseFalcoExceptionHandler (exceptionHandler : HttpHandler) =
             let configure (appBuilder : IApplicationBuilder) =

--- a/src/Falco/HostBuilder.fs
+++ b/src/Falco/HostBuilder.fs
@@ -1,4 +1,4 @@
-﻿namespace Falco.HostBuilder
+namespace Falco.HostBuilder
 
 open System
 open Falco
@@ -27,7 +27,7 @@ type HostBuilderSpec =
           NotFound = None
           Endpoints = [] }
 
-/// Computation expression to allow for elegant IHost construction
+/// Computation expression to allow for elegant IHost construction.
 type HostBuilder(args : string[]) =
     member _.Yield(_) = HostBuilderSpec.Empty
 
@@ -68,18 +68,18 @@ type HostBuilder(args : string[]) =
 
         app.Run()
 
-    /// Register Falco HttpEndpoint's
+    /// Registers Falco HttpEndpoint's.
     [<CustomOperation("endpoints")>]
     member _.Endpoints (conf : HostBuilderSpec, endpoints : HttpEndpoint list) =
         { conf with Endpoints = endpoints }
 
 
-    /// Configure logging via ILogger
+    /// Configures logging via ILogger.
     [<CustomOperation("host")>]
     member _.Host (conf : HostBuilderSpec, fn : IHostBuilder -> IHostBuilder) =
         { conf with Host = conf.Host >> fn }
 
-    /// Configure logging via ILoggingBuilder
+    /// Configures logging via ILoggingBuilder.
     [<CustomOperation("logging")>]
     member _.Logging (conf : HostBuilderSpec, fn : ILoggingBuilder -> ILoggingBuilder) =
         { conf with Logging = conf.Logging >> fn }
@@ -88,17 +88,17 @@ type HostBuilder(args : string[]) =
     // Service Collection
     // ------------
 
-    /// Add a new service descriptor into the IServiceCollection.
+    /// Adds a new service descriptor into the IServiceCollection.
     [<CustomOperation("add_service")>]
     member _.AddService (conf : HostBuilderSpec, fn : IServiceCollection -> IServiceCollection) =
         { conf with Services = conf.Services >> fn }
 
-    /// Add Antiforgery support into the IServiceCollection.
+    /// Adds Antiforgery support into the IServiceCollection.
     [<CustomOperation("add_antiforgery")>]
     member x.AddAntiforgery (conf : HostBuilderSpec) =
         x.AddService (conf, fun s -> s.AddAntiforgery())
 
-    /// Add configured cookie(s) authentication into the IServiceCollection.
+    /// Adds configured cookie(s) authentication into the IServiceCollection.
     [<CustomOperation("add_cookies")>]
     member x.AddCookies (
         conf : HostBuilderSpec,
@@ -114,18 +114,18 @@ type HostBuilder(args : string[]) =
 
         x.AddService (conf, addAuthentication)
 
-    /// Add default cookie authentication into the IServiceCollection.
+    /// Adds default cookie authentication into the IServiceCollection.
     [<CustomOperation("add_cookie")>]
     member x.AddCookie (conf : HostBuilderSpec, scheme : string, config : CookieAuthenticationOptions -> unit) =
         x.AddService (conf, fun s -> s.AddAuthentication(scheme).AddCookie(config) |> ignore; s)
 
 
-    /// Add default Authorization into the IServiceCollection.
+    /// Adds default Authorization into the IServiceCollection.
     [<CustomOperation("add_authorization")>]
     member x.AddAuthorization (conf : HostBuilderSpec) =
         x.AddService (conf, fun svc -> svc.AddAuthorization())
 
-    /// Add file system based data protection.
+    /// Adds file system based data protection.
     [<CustomOperation("add_data_protection")>]
     member x.AddDataProtection (conf : HostBuilderSpec, dir : string) =
         let addDataProtection (svc : IServiceCollection) =
@@ -135,7 +135,7 @@ type HostBuilder(args : string[]) =
 
         x.AddService (conf, addDataProtection)
 
-    /// Add IHttpClientFactory into the IServiceCollection
+    /// Adds IHttpClientFactory into the IServiceCollection.
     [<CustomOperation("add_http_client")>]
     member x.AddHttpClient (conf : HostBuilderSpec) =
         x.AddService (conf, fun svc -> svc.AddHttpClient())
@@ -144,42 +144,42 @@ type HostBuilder(args : string[]) =
     // Application Builder
     // ------------
 
-    /// Use the specified middleware.
+    /// Uses the specified middleware.
     [<CustomOperation("use_middleware")>]
     member _.Use (conf : HostBuilderSpec, fn : IApplicationBuilder -> IApplicationBuilder) =
         { conf with Middleware = conf.Middleware >> fn }
 
-    /// Use the specified middleware if the provided predicate is "true".
+    /// Uses the specified middleware if the provided predicate is "true".
     [<CustomOperation("use_if")>]
     member _.UseIf (conf : HostBuilderSpec, pred : IApplicationBuilder -> bool, fn : IApplicationBuilder -> IApplicationBuilder) =
         { conf with Middleware = fun app -> if pred app then conf.Middleware(app) |> fn else conf.Middleware(app) }
 
-    /// Use the specified middleware if the provided predicate is "true".
+    /// Uses the specified middleware if the provided predicate is "false".
     [<CustomOperation("use_ifnot")>]
     member _.UseIfNot (conf : HostBuilderSpec, pred : IApplicationBuilder -> bool, fn : IApplicationBuilder -> IApplicationBuilder) =
         { conf with Middleware = fun app -> if not(pred app) then conf.Middleware(app) |> fn else conf.Middleware(app) }
 
-    /// Use authorization middleware. Call before any middleware that depends
+    /// Uses authorization middleware. Call before any middleware that depends
     /// on users being authenticated.
     [<CustomOperation("use_authentication")>]
     member x.UseAuthentication (conf : HostBuilderSpec) =
         x.Use (conf, fun app -> app.UseAuthentication())
 
-    /// Register authorization service and enable middleware
+    /// Registers authorization service and enables middleware.
     [<CustomOperation("use_authorization")>]
     member _.UseAuthorization (conf : HostBuilderSpec) =
         { conf with
                Services = conf.Services >> fun s -> s.AddAuthorization()
                Middleware = conf.Middleware >> fun app -> app.UseAuthorization() }
 
-    /// Register HTTP Response caching service and enable middleware.
+    /// Registers HTTP Response caching service and enables middleware.
     [<CustomOperation("use_caching")>]
     member x.UseCaching(conf : HostBuilderSpec) =
         { conf with
                Services = conf.Services >> fun s -> s.AddResponseCaching()
                Middleware = conf.Middleware >> fun app -> app.UseResponseCaching() }
 
-    /// Register Brotli + GZip HTTP Compression service and enable middleware.
+    /// Registers Brotli + GZip HTTP Compression service and enables middleware.
     [<CustomOperation("use_compression")>]
     member _.UseCompression (conf : HostBuilderSpec) =
         let configureCompression (s : IServiceCollection) =
@@ -205,17 +205,17 @@ type HostBuilder(args : string[]) =
                Services = conf.Services >> configureCompression
                Middleware = conf.Middleware >> fun app -> app.UseResponseCompression() }
 
-    /// Use automatic HSTS middleware (adds strict-transport-policy header).
+    /// Uses automatic HSTS middleware (adds strict-transport-policy header).
     [<CustomOperation("use_hsts")>]
     member x.UseHsts (conf : HostBuilderSpec) =
         x.Use (conf, fun app -> app.UseHsts())
 
-    /// Use automatic HTTPS redirection.
+    /// Uses automatic HTTPS redirection.
     [<CustomOperation("use_https")>]
     member x.UseHttps (conf : HostBuilderSpec) =
         x.Use (conf, fun app -> app.UseHttpsRedirection())
 
-    /// Use Default File middleware. Must be called before use_static_files
+    /// Uses Default File middleware. Must be called before use_static_files.
     [<CustomOperation("use_default_files")>]
     member _.UseDefaultFiles (conf : HostBuilderSpec, ?config : DefaultFilesOptions) =
         let configureDefaultFiles (app : IApplicationBuilder) =
@@ -225,7 +225,7 @@ type HostBuilder(args : string[]) =
 
         { conf with Middleware = conf.Middleware >> configureDefaultFiles }
 
-    /// Use Static File middleware.
+    /// Uses Static File middleware.
     [<CustomOperation("use_static_files")>]
     member _.UseStaticFiles (conf : HostBuilderSpec, ?config : StaticFileOptions) =
         let configureStaticFiles (app : IApplicationBuilder) =
@@ -239,12 +239,12 @@ type HostBuilder(args : string[]) =
     // Errors
     // ------------
 
-    /// Include a catch-all (i.e., Not Found) HttpHandler (must be added last).
+    /// Includes a catch-all (i.e., Not Found) HttpHandler (must be added last).
     [<CustomOperation("not_found")>]
     member _.NotFound (conf : HostBuilderSpec, handler : HttpHandler) =
         { conf with NotFound = Some handler }
 
 [<AutoOpen>]
 module WebHostBuilder =
-    /// Computation expression to allow for elegant IHost construction
+    /// Computation expression to allow for elegant IHost construction.
     let webHost args = HostBuilder(args)

--- a/src/Falco/Multipart.fs
+++ b/src/Falco/Multipart.fs
@@ -1,4 +1,4 @@
-﻿namespace Falco
+namespace Falco
 
 open System
 open System.IO
@@ -16,13 +16,13 @@ module Multipart =
         | FormFileData of FormFile
 
     type private MultipartSection with
-        /// Attempt to obtain encoding from content type, default to UTF8.
-        static member private GetEncondingFromContentType(section : MultipartSection) =
+        /// Attempts to obtain encoding from content type, default to UTF8.
+        static member private GetEncodingFromContentType(section : MultipartSection) =
             match MediaTypeHeaderValue.TryParse(StringSegment(section.ContentType)) with
             | false, _     -> System.Text.Encoding.UTF8
             | true, parsed -> parsed.Encoding
 
-        /// Safely obtain the content disposition header value.
+        /// Safely obtains the content disposition header value.
         static member private TryGetContentDisposition(section : MultipartSection) =
             match ContentDispositionHeaderValue.TryParse(StringSegment(section.ContentDisposition)) with
             | false, _     -> None
@@ -50,7 +50,7 @@ module Multipart =
 
                 | Some cd when cd.IsFormDisposition() ->
                     let key = HeaderUtilities.RemoveQuotes(cd.Name).Value
-                    let encoding = MultipartSection.GetEncondingFromContentType(x)
+                    let encoding = MultipartSection.GetEncodingFromContentType(x)
                     use str = new StreamReader(x.Body, encoding, true, 1024, true)
                     let! formValue = str.ReadToEndAsync()
 
@@ -105,7 +105,7 @@ module Multipart =
             | b when b.Length > lengthLimit -> None
             | b                             -> Some b
 
-        /// Attempt to stream the HttpRequest body into IFormCollection.
+        /// Attempts to stream the HttpRequest body into IFormCollection.
         member x.StreamFormAsync () : Task<IFormCollection> =
             task {
                 match x.IsMultipart(), x.GetBoundary() with

--- a/src/Falco/Request.fs
+++ b/src/Falco/Request.fs
@@ -1,4 +1,4 @@
-﻿[<RequireQualifiedAccess>]
+[<RequireQualifiedAccess>]
 module Falco.Request
 
 open System.IO
@@ -24,7 +24,7 @@ let private httpPipeTask
         return next x ctx
     }
 
-/// Obtain the HttpVerb of the request
+/// Obtains the HttpVerb of the request
 let getVerb (ctx : HttpContext) : HttpVerb =
     match ctx.Request.Method with
     | m when strEquals m HttpMethods.Get     -> GET
@@ -37,32 +37,32 @@ let getVerb (ctx : HttpContext) : HttpVerb =
     | m when strEquals m HttpMethods.Trace   -> TRACE
     | _ -> ANY
 
-/// Stream the request body into a string.
+/// Streams the request body into a string.
 let getBodyString (ctx : HttpContext) : Task<string> =
     task {
         use reader = new StreamReader(ctx.Request.Body, Encoding.UTF8)
         return! reader.ReadToEndAsync()
     }
 
-/// Retrieve the cookie from the request as an instance of
+/// Retrieves the cookie from the request as an instance of
 /// CookieCollectionReader.
 let getCookie (ctx : HttpContext) : CookieCollectionReader =
     CookieCollectionReader(ctx.Request.Cookies)
 
-/// Retrieve a specific header from the request.
+/// Retrieves a specific header from the request.
 let getHeaders (ctx : HttpContext) : HeaderCollectionReader  =
     HeaderCollectionReader(ctx.Request.Headers)
 
-/// Retrieve all route values from the request as RouteCollectionReader.
+/// Retrieves all route values from the request as RouteCollectionReader.
 let getRoute (ctx : HttpContext) : RouteCollectionReader =
     RouteCollectionReader(ctx.Request.RouteValues, ctx.Request.Query)
 
-/// Retrieve the query string from the request as an instance of
+/// Retrieves the query string from the request as an instance of
 /// QueryCollectionReader.
 let getQuery (ctx : HttpContext) : QueryCollectionReader =
     QueryCollectionReader(ctx.Request.Query)
 
-/// Retrieve the form collection from the request as an instance of
+/// Retrieves the form collection from the request as an instance of
 /// FormCollectionReader.
 let getForm (ctx : HttpContext) : Task<FormCollectionReader> =
     task {
@@ -71,14 +71,14 @@ let getForm (ctx : HttpContext) : Task<FormCollectionReader> =
         return FormCollectionReader(form, files)
     }
 
-/// Attempt to bind request body using System.Text.Json and provided
+/// Attempts to bind request body using System.Text.Json and provided
 /// JsonSerializerOptions.
 let getJsonOptions<'T>
     (options : JsonSerializerOptions)
     (ctx : HttpContext) : Task<'T> =
     JsonSerializer.DeserializeAsync<'T>(ctx.Request.Body, options).AsTask()
 
-/// Stream the form collection for multipart form submissions.
+/// Streams the form collection for multipart form submissions.
 let streamForm
     (ctx : HttpContext) : Task<FormCollectionReader> =
     task {
@@ -91,34 +91,34 @@ let streamForm
 // Handlers
 // ------------
 
-/// Buffer the current HttpRequest body into a
-/// string and provide to next HttpHandler.
+/// Buffers the current HttpRequest body into a
+/// string and provides to next HttpHandler.
 let bodyString
     (next : string -> HttpHandler) : HttpHandler =
     httpPipeTask getBodyString next
 
-/// Project CookieCollectionReader onto 'T and provide
+/// Projects CookieCollectionReader onto 'T and provides
 /// to next HttpHandler.
 let mapCookie
     (map : CookieCollectionReader -> 'T)
     (next : 'T -> HttpHandler) : HttpHandler =
     httpPipe getCookie (map >> next)
 
-/// Project HeaderCollectionReader onto 'T and provide
+/// Projects HeaderCollectionReader onto 'T and provides
 /// to next HttpHandler.
 let mapHeader
     (map : HeaderCollectionReader -> 'T)
     (next : 'T -> HttpHandler) : HttpHandler =
     httpPipe getHeaders (map >> next)
 
-/// Project RouteCollectionReader onto 'T and provide
+/// Projects RouteCollectionReader onto 'T and provides
 /// to next HttpHandler.
 let mapRoute
     (map : RouteCollectionReader -> 'T)
     (next : 'T -> HttpHandler) : HttpHandler =
     httpPipe getRoute (map >> next)
 
-/// Project QueryCollectionReader onto 'T and provide
+/// Projects QueryCollectionReader onto 'T and provides
 /// to next HttpHandler.
 let mapQuery
     (map : QueryCollectionReader -> 'T)
@@ -126,15 +126,15 @@ let mapQuery
     httpPipe getQuery (map >> next)
 
 
-/// Project FormCollectionReader onto 'T and provide
+/// Projects FormCollectionReader onto 'T and provides
 /// to next HttpHandler.
 let mapForm
     (map : FormCollectionReader -> 'T)
     (next : 'T -> HttpHandler) : HttpHandler =
     httpPipeTask getForm (map >> next)
 
-/// Stream multipart/form-data into FormCollectionReader and project onto 'T
-/// provide to next HttpHandler.
+/// Streams multipart/form-data into FormCollectionReader and projects onto 'T
+/// and provides to next HttpHandler.
 ///
 /// Important: This is intended to be used with multipart/form-data submissions
 /// and will not work if this content-type is not present.
@@ -143,7 +143,7 @@ let mapFormStream
     (next : 'T -> HttpHandler) : HttpHandler =
     httpPipeTask streamForm (map >> next)
 
-/// Validate the CSRF of the current request.
+/// Validates the CSRF of the current request.
 let validateCsrfToken
     (handleOk : HttpHandler)
     (handleInvalidToken : HttpHandler) : HttpHandler = fun ctx ->
@@ -158,7 +158,7 @@ let validateCsrfToken
         return! respondWith ctx
     }
 
-/// Project FormCollectionReader onto 'T and provide
+/// Projects FormCollectionReader onto 'T and provides
 /// to next HttpHandler.
 let mapFormSecure
     (map : FormCollectionReader -> 'T)
@@ -168,8 +168,8 @@ let mapFormSecure
         (mapForm map next)
         handleInvalidToken
 
-/// Stream multipart/form-data into FormCollectionReader and project onto 'T
-/// provide to next HttpHandler.
+/// Streams multipart/form-data into FormCollectionReader and projects onto 'T
+/// and provides to next HttpHandler.
 ///
 /// Important: This is intended to be used with multipart/form-data submissions
 /// and will not work if this content-type is not present.
@@ -182,9 +182,9 @@ let mapFormStreamSecure
         handleInvalidToken
         ctx
 
-/// Project JSON using custom JsonSerializerOptions
-/// onto 'T and provide to next Httphandler, throws
-/// JsonException if errors occurs during deserialization.
+/// Projects JSON using custom JsonSerializerOptions
+/// onto 'T and provides to next HttpHandler, throws
+/// JsonException if errors occur during deserialization.
 let mapJsonOption
     (options : JsonSerializerOptions)
     (next : 'T -> HttpHandler) : HttpHandler =
@@ -196,9 +196,9 @@ let internal defaultJsonOptions =
     options.PropertyNameCaseInsensitive <- true
     options
 
-/// Project JSON onto 'T and provide to next
-/// Httphandler, throws JsonException if errors
-/// occurs during deserialization.
+/// Projects JSON onto 'T and provides to next
+/// HttpHandler, throws JsonException if errors
+/// occur during deserialization.
 let mapJson
     (next : 'T -> HttpHandler) : HttpHandler =
     mapJsonOption defaultJsonOptions next
@@ -207,14 +207,14 @@ let mapJson
 // Authentication
 // ------------
 
-/// Attempt to authenticate the current request using the provided
-/// scheme and pass AuthenticateResult into next HttpHandler.
+/// Attempts to authenticate the current request using the provided
+/// scheme and passes AuthenticateResult into next HttpHandler.
 let authenticate
     (scheme : string)
     (next : AuthenticateResult -> HttpHandler) : HttpHandler =
     httpPipeTask (Auth.authenticate scheme) next
 
-/// Proceed if the authentication status of current IPrincipal is true.
+/// Proceeds if the authentication status of current IPrincipal is true.
 let ifAuthenticated
     (handleOk : HttpHandler)
     (handleError : HttpHandler) : HttpHandler =
@@ -222,7 +222,7 @@ let ifAuthenticated
         Auth.isAuthenticated
         (function true -> handleOk | false -> handleError)
 
-/// Proceed if the authentication status of current IPrincipal is true
+/// Proceeds if the authentication status of current IPrincipal is true
 /// and they exist in a list of roles.
 let ifAuthenticatedInRole
     (roles : string list)
@@ -236,7 +236,7 @@ let ifAuthenticatedInRole
         | true, true -> handleOk ctx
         | _          -> handleError ctx
 
-/// Proceed if the authentication status of current IPrincipal is true
+/// Proceeds if the authentication status of current IPrincipal is true
 /// and has a specific scope.
 let ifAuthenticatedWithScope
     (issuer : string)
@@ -251,7 +251,7 @@ let ifAuthenticatedWithScope
         | true, true -> handleOk ctx
         | _          -> handleError ctx
 
-/// Proceed if the authentication status of current IPrincipal is false.
+/// Proceeds if the authentication status of current IPrincipal is false.
 let ifNotAuthenticated
     (handleOk : HttpHandler)
     (handleError : HttpHandler) : HttpHandler =

--- a/src/Falco/Response.fs
+++ b/src/Falco/Response.fs
@@ -1,4 +1,4 @@
-﻿[<RequireQualifiedAccess>]
+[<RequireQualifiedAccess>]
 module Falco.Response
 
 open System
@@ -19,7 +19,7 @@ open Microsoft.Net.Http.Headers
 // Modifiers
 // ------------
 
-/// Set multiple headers for response.
+/// Sets multiple headers for response.
 let withHeaders
     (headers : (string * string) list) : HttpResponseModifier = fun ctx ->
     let setHeader (name, content : string) =
@@ -29,12 +29,12 @@ let withHeaders
     headers |> List.iter setHeader
     ctx
 
-/// Set ContentLength for response.
+/// Sets ContentLength for response.
 let withContentLength
     (contentLength : int64) : HttpResponseModifier =
     withHeaders [ HeaderNames.ContentLength, (string contentLength) ]
 
-/// Set ContentType header for response.
+/// Sets ContentType header for response.
 let withContentType
     (contentType : string) : HttpResponseModifier =
     withHeaders [ HeaderNames.ContentType, contentType ]
@@ -45,14 +45,14 @@ let withStatusCode
     ctx.Response.StatusCode <- statusCode
     ctx
 
-/// Add cookie to response.
+/// Adds cookie to response.
 let withCookie
     (key : string)
     (value : string) : HttpResponseModifier = fun ctx ->
     ctx.Response.Cookies.Append(key, value)
     ctx
 
-/// Add a configured cookie to response, via CookieOptions.
+/// Adds a configured cookie to response, via CookieOptions.
 let withCookieOptions
     (options : CookieOptions)
     (key : string)
@@ -114,7 +114,7 @@ let ofBinary
 /// Content-Type and optional filename.
 ///
 /// Note: Automatically sets "content-disposition: attachment" and includes
-/// filename if provided
+/// filename if provided.
 let ofAttachment
     (filename : string)
     (contentType : string)
@@ -202,7 +202,7 @@ let ofJson
     withContentType "application/json; charset=utf-8"
     >> ofJsonOptions Request.defaultJsonOptions obj
 
-/// Sign in claim principal for provided scheme then respond with a 301 redirect
+/// Signs in claim principal for provided scheme then responds with a 301 redirect
 /// to provided URL.
 let signInAndRedirect
     (authScheme : string)
@@ -213,7 +213,7 @@ let signInAndRedirect
         do! redirectTemporarily url ctx
     }
 
-/// Sign in claim principal for provided scheme and options then respond with a
+/// Signs in claim principal for provided scheme and options then responds with a
 /// 301 redirect to provided URL.
 let signInOptionsAndRedirect
     (authScheme : string)
@@ -225,7 +225,7 @@ let signInOptionsAndRedirect
         do! redirectTemporarily url ctx
     }
 
-/// Terminates authenticated context for provided scheme then respond with a 301
+/// Terminates authenticated context for provided scheme then responds with a 301
 /// redirect to provided URL.
 let signOutAndRedirect
     (authScheme : string)
@@ -235,7 +235,7 @@ let signOutAndRedirect
         do! redirectTemporarily url ctx
     }
 
-/// Challenge the specified authentication scheme.
+/// Challenges the specified authentication scheme.
 /// An authentication challenge can be issued when an unauthenticated user
 /// requests an endpoint that requires authentication. Then given redirectUri is
 /// forwarded to the authentication handler for use after authentication succeeds.
@@ -247,7 +247,7 @@ let challengeWithRedirect
         do! Auth.challenge authScheme properties ctx
     }
 
-/// Pretty print the content of the current request to the screen.
+/// Pretty prints the content of the current request to the screen.
 ///
 /// Important: This is intended to be used for debugging during
 /// development only. DO NOT USE in production.

--- a/src/Falco/Security.fs
+++ b/src/Falco/Security.fs
@@ -5,19 +5,19 @@ module Crypto =
     open System.Text
     open System.Security.Cryptography
 
-    /// Make byte[] from Base64 string.
+    /// Makes byte[] from Base64 string.
     let private bytesFromBase64 (str : string) =
         Convert.FromBase64String str
 
-    /// Make Base64 string from byte[].
+    /// Makes Base64 string from byte[].
     let private bytesToBase64 (bytes : byte[]) =
         Convert.ToBase64String bytes
 
-    /// Generate a random int32 between range.
+    /// Generates a random Int32 between range.
     let randomInt min max =
         RandomNumberGenerator.GetInt32(min,max)
 
-    /// Generate cryptographically-sound random salt.
+    /// Generates cryptographically-sound random salt.
     ///
     /// Example: `createSalt 16 (generates a 128-bit (i.e. 128 / 8) salt).`
     let createSalt len =
@@ -26,7 +26,7 @@ module Crypto =
         rng.GetBytes rndAry
         rndAry |> bytesToBase64
 
-    /// Perform key derivation using the provided algorithm.
+    /// Performs key derivation using the provided algorithm.
     let pbkdf2
         (algo : HashAlgorithmName)
         (iterations : int)
@@ -37,7 +37,7 @@ module Crypto =
         let bytes = pbkdf2.GetBytes numBytesRequested
         bytesToBase64 bytes
 
-    /// Perform PBKDF2 key derivation using HMACSHA256.
+    /// Performs PBKDF2 key derivation using HMACSHA256.
     let sha256
         (iterations : int)
         (numBytesRequested : int)
@@ -50,7 +50,7 @@ module Crypto =
             (Encoding.UTF8.GetBytes salt)
             (Encoding.UTF8.GetBytes strToHash)
 
-    /// Perform key derivation using HMACSHA512.
+    /// Performs key derivation using HMACSHA512.
     let sha512
         (iterations : int)
         (numBytesRequested : int)
@@ -70,7 +70,7 @@ module Xss =
     open Microsoft.AspNetCore.Antiforgery
     open Microsoft.AspNetCore.Http
 
-    /// Output an antiforgery <input type="hidden" />.
+    /// Outputs an antiforgery <input type="hidden" />.
     let antiforgeryInput
         (token : AntiforgeryTokenSet) =
         Elem.input [
@@ -84,7 +84,7 @@ module Xss =
         let antiFrg = ctx.GetService<IAntiforgery>()
         antiFrg.GetAndStoreTokens ctx
 
-    /// Validate the Antiforgery token within the provided HttpContext.
+    /// Validates the Antiforgery token within the provided HttpContext.
     let validateToken (ctx : HttpContext) : Task<bool> =
         let antiFrg = ctx.GetService<IAntiforgery>()
         antiFrg.IsRequestValidAsync ctx
@@ -174,14 +174,14 @@ module Auth =
         | None       -> false
         | Some claim -> Array.contains scope (strSplit [|' '|] claim.Value)
 
-    /// Establish an authenticated context for the provide scheme and principal.
+    /// Establishes an authenticated context for the provide scheme and principal.
     let signIn
         (authScheme : string)
         (claimsPrincipal : ClaimsPrincipal)
         (ctx : HttpContext) : Task =
         ctx.SignInAsync(authScheme, claimsPrincipal)
 
-    /// Establish an authenticated context for the provide scheme, options and
+    /// Establishes an authenticated context for the provide scheme, options and
     /// principal.
     let signInOptions
         (authScheme : string)
@@ -190,13 +190,13 @@ module Auth =
         (ctx : HttpContext) : Task =
         ctx.SignInAsync(authScheme, claimsPrincipal, options)
 
-    /// Terminate authenticated context for provided scheme.
+    /// Terminates authenticated context for provided scheme.
     let signOut
         (authScheme : string)
         (ctx : HttpContext) : Task =
         ctx.SignOutAsync(authScheme)
 
-    /// Challenge the specified authentication scheme.
+    /// Challenges the specified authentication scheme.
     ///
     /// An authentication challenge can be issued when an unauthenticated user
     /// requests an endpoint that requires authentication.

--- a/src/Falco/String.fs
+++ b/src/Falco/String.fs
@@ -35,10 +35,9 @@ module internal StringParser =
 
     let parseNonEmptyString x = if StringUtils.strEmpty x then None else Some x
 
-    let parseInt            = tryParseWith Int32.TryParse
     let parseInt16          = tryParseWith Int16.TryParse
-    let parseInt32          = parseInt
     let parseInt64          = tryParseWith Int64.TryParse
+    let parseInt32          = tryParseWith Int32.TryParse
     let parseFloat          = tryParseWith Double.TryParse
     let parseDecimal        = tryParseWith Decimal.TryParse
     let parseDateTime       = tryParseWith DateTime.TryParse

--- a/src/Falco/String.fs
+++ b/src/Falco/String.fs
@@ -1,27 +1,27 @@
-﻿namespace Falco
+namespace Falco
 
 open System
 
 module internal StringUtils =
-    /// Check if string is null or whitespace.
+    /// Checks if string is null or whitespace.
     let strEmpty str =
         String.IsNullOrWhiteSpace(str)
 
-    /// Check if string is not null or whitespace.
+    /// Checks if string is not null or whitespace.
     let strNotEmpty str =
         not(strEmpty str)
 
-    /// Case & culture insensistive string equality.
+    /// Case & culture insensitive string equality.
     let strEquals s1 s2 =
         String.Equals(s1, s2, StringComparison.InvariantCultureIgnoreCase)
 
-    /// Concat strings.
+    /// Concats strings.
     let strConcat (list : string seq) =
         // String.Concat uses a StringBuilder when provided an IEnumerable
         // Url: https://github.com/microsoft/referencesource/blob/master/mscorlib/system/string.cs#L161
         String.Concat(list)
 
-    /// Split string into substrings based on separator.
+    /// Splits string into substrings based on separator.
     let strSplit (sep : char array) (str : string) =
         str.Split(sep)
 
@@ -46,7 +46,7 @@ module internal StringParser =
     let parseTimeSpan       = tryParseWith TimeSpan.TryParse
     let parseGuid           = tryParseWith Guid.TryParse
 
-    /// Attempt to parse boolean from string.
+    /// Attempts to parse boolean from string.
     ///
     /// Returns None on failure, Some x on success.
     ///
@@ -60,13 +60,13 @@ module internal StringParser =
         | "OFF" | "NO" | "0" -> Some false
         | v -> tryParseWith Boolean.TryParse v
 
-    /// Attempt to parse, or failwith message.
+    /// Attempts to parse, or failwith message.
     let parseOrFail parser msg v =
         match parser v with
         | Some v -> v
         | None   -> failwith msg
 
-    /// Attempt to parse array, returns none for failure.
+    /// Attempts to parse array, returns none for failure.
     let tryParseArray parser ary =
         ary
         |> List.ofArray

--- a/src/Falco/StringCollectionReader.fs
+++ b/src/Falco/StringCollectionReader.fs
@@ -1,4 +1,4 @@
-﻿namespace Falco
+namespace Falco
 
 open System
 open System.Collections.Generic
@@ -25,7 +25,7 @@ type StringCollectionReader (values : Map<string, string[]>) =
     /// The keys in the collection reader.
     member _.Keys = values.Keys
 
-    /// Safely retrieve a collection of readers.
+    /// Safely retrieves a collection of readers.
     ///
     /// Intended to be used with the "dot notation" collection wire format.
     /// (i.e., Person.First=John&Person.Last=Doe&Person.First=Jane&Person.Last=Doe)
@@ -63,144 +63,144 @@ type StringCollectionReader (values : Map<string, string[]>) =
             |> List.map (Map.ofList >> StringCollectionReader)
 
 
-    // Primitive returing Option<'T>
+    // Primitive returning Option<'T>
 
-    /// Safely retrieve String option (alias for StringCollectionReader.TryGetString).
+    /// Safely retrieves String option (alias for StringCollectionReader.TryGetString).
     member x.TryGet (name : string) =
         x.TryGetBind (fun v -> Some v) name
 
-    /// Safely retrieve String option.
+    /// Safely retrieves String option.
     member x.TryGetString (name : string) =
         x.TryGet name
 
-    /// Safely retrieve non-empty String option.
+    /// Safely retrieves non-empty String option.
     member x.TryGetStringNonEmpty (name : string) =
         x.TryGetBind (fun v -> parseNonEmptyString v) name
 
-    /// Safely retrieve Int16 option.
+    /// Safely retrieves Int16 option.
     member x.TryGetInt16 (name : string) =
         x.TryGetBind (fun v -> parseInt16 v) name
 
-    /// Safely retrieve Int32 option.
+    /// Safely retrieves Int32 option.
     member x.TryGetInt32 (name : string) =
         x.TryGetBind (fun v -> parseInt32 v) name
 
-    /// Safely retrieve Int option.
+    /// Safely retrieves Int option.
     member x.TryGetInt (name : string) =
         x.TryGetInt32 name
 
-    /// Safely retrieve Int64 option.
+    /// Safely retrieves Int64 option.
     member x.TryGetInt64 (name : string) =
         x.TryGetBind (fun v -> parseInt64 v) name
 
-    /// Safely retrieve Boolean option.
+    /// Safely retrieves Boolean option.
     member x.TryGetBoolean (name : string) =
         x.TryGetBind (fun v -> parseBoolean v) name
 
-    /// Safely retrieve Float option.
+    /// Safely retrieves Float option.
     member x.TryGetFloat (name : string) =
         x.TryGetBind (fun v -> parseFloat v) name
 
-    /// Safely retrieve Decimal option.
+    /// Safely retrieves Decimal option.
     member x.TryGetDecimal (name : string) =
         x.TryGetBind (fun v -> parseDecimal v) name
 
-    /// Safely retrieve DateTime option.
+    /// Safely retrieves DateTime option.
     member x.TryGetDateTime (name : string) =
         x.TryGetBind (fun v -> parseDateTime v) name
 
-    /// Safely retrieve DateTimeOffset option.
+    /// Safely retrieves DateTimeOffset option.
     member x.TryGetDateTimeOffset (name : string) =
         x.TryGetBind (fun v -> parseDateTimeOffset v) name
 
-    /// Safely retrieve Guid option.
+    /// Safely retrieves Guid option.
     member x.TryGetGuid (name : string) =
         x.TryGetBind (fun v -> parseGuid v) name
 
-    /// Safely retrieve TimeSpan option.
+    /// Safely retrieves TimeSpan option.
     member x.TryGetTimeSpan (name : string) =
         x.TryGetBind (fun v -> parseTimeSpan v) name
 
 
     // Primitives - Get or Default
 
-    /// Safely retrieve named String or defaultValue.
+    /// Safely retrieves named String or defaultValue.
     member x.Get (name : string, ?defaultValue : String) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue "")
             (x.TryGet name)
 
-    /// Safely retrieve named string or defaultValue.
+    /// Safely retrieves named String or defaultValue.
     member x.GetString (name : string, ?defaultValue : String) =
         x.Get (name, ?defaultValue=defaultValue)
 
-    /// Safely retrieve named non-empty String or defaultValue.
+    /// Safely retrieves named non-empty String or defaultValue.
     member x.GetStringNonEmpty (name : string, ?defaultValue : String) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue "")
             (x.TryGetStringNonEmpty name)
 
-    /// Safely retrieve named Int16 or defaultValue.
+    /// Safely retrieves named Int16 or defaultValue.
     member x.GetInt16 (name : string, ?defaultValue : Int16) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue 0s)
             (x.TryGetInt16 name)
 
-    /// Safely retrieve named Int32 or defaultValue.
+    /// Safely retrieves named Int32 or defaultValue.
     member x.GetInt32 (name : string, ?defaultValue : Int32) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue 0)
             (x.TryGetInt32 name)
 
-    /// Safely retrieve named Int or defaultValue.
+    /// Safely retrieves named Int or defaultValue.
     member x.GetInt (name : string, ?defaultValue : Int32) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue 0)
             (x.TryGetInt name)
 
-    /// Safely retrieve named Int64 or defaultValue.
+    /// Safely retrieves named Int64 or defaultValue.
     member x.GetInt64 (name : string, ?defaultValue : Int64) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue 0L)
             (x.TryGetInt64 name)
 
-    /// Safely retrieve named Boolean or defaultValue.
+    /// Safely retrieves named Boolean or defaultValue.
     member x.GetBoolean (name : string, ?defaultValue : Boolean) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue false)
             (x.TryGetBoolean name)
 
-    /// Safely retrieve named Float or defaultValue.
+    /// Safely retrieves named Float or defaultValue.
     member x.GetFloat (name : string, ?defaultValue : float) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue 0)
             (x.TryGetFloat name)
 
-    /// Safely retrieve named Decimal or defaultValue.
+    /// Safely retrieves named Decimal or defaultValue.
     member x.GetDecimal (name : string, ?defaultValue : Decimal) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue 0M)
             (x.TryGetDecimal name)
 
-    /// Safely retrieve named DateTime or defaultValue.
+    /// Safely retrieves named DateTime or defaultValue.
     member x.GetDateTime (name : string, ?defaultValue : DateTime) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue DateTime.MinValue)
             (x.TryGetDateTime name)
 
-    /// Safely retrieve named DateTimeOffset or defaultValue.
+    /// Safely retrieves named DateTimeOffset or defaultValue.
     member x.GetDateTimeOffset (name : string, ?defaultValue : DateTimeOffset) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue DateTimeOffset.MinValue)
             (x.TryGetDateTimeOffset name)
 
-    /// Safely retrieve named Guid or defaultValue.
+    /// Safely retrieves named Guid or defaultValue.
     member x.GetGuid (name : string, ?defaultValue : Guid) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue Guid.Empty)
             (x.TryGetGuid name)
 
-    /// Safely retrieve named TimeSpan or defaultValue.
+    /// Safely retrieves named TimeSpan or defaultValue.
     member x.GetTimeSpan (name : string, ?defaultValue : TimeSpan) =
         Option.defaultWith
             (fun () -> defaultArg defaultValue TimeSpan.MinValue)
@@ -209,59 +209,59 @@ type StringCollectionReader (values : Map<string, string[]>) =
 
     // Array Primitives
 
-    /// Safely retrieve the named String[].
+    /// Safely retrieves the named String[].
     member x.GetStringArray (name : string) =
         x.TryGetMapArray Some name
 
-    /// Safely retrieve the named String[].
+    /// Safely retrieves the named String[].
     member x.GetArray (name : string) =
         x.TryGetMapArray Some name
 
-    /// Safely retrieve the named String[] excluding empty & null values.
+    /// Safely retrieves the named String[] excluding empty & null values.
     member x.GetStringNonEmptyArray (name : string) =
         x.TryGetMapArray parseNonEmptyString name
 
-    /// Safely retrieve the named Int16[].
+    /// Safely retrieves the named Int16[].
     member x.GetInt16Array (name : string) =
         x.TryGetMapArray parseInt16 name
 
-    /// Safely retrieve the named Int32[].
+    /// Safely retrieves the named Int32[].
     member x.GetInt32Array (name : string) =
         x.TryGetMapArray parseInt32 name
 
-    /// Safely retrieve the named Int[] (alias for StringCollectionReader.TryArrayInt32).
+    /// Safely retrieves the named Int[] (alias for StringCollectionReader.TryArrayInt32).
     member x.GetIntArray (name : string) =
         x.GetInt32Array name
 
-    /// Safely retrieve the named Int64[].
+    /// Safely retrieves the named Int64[].
     member x.GetInt64Array (name : string) =
         x.TryGetMapArray parseInt64 name
 
-    /// Safely retrieve the named Boolean[].
+    /// Safely retrieves the named Boolean[].
     member x.GetBooleanArray (name : string) =
         x.TryGetMapArray parseBoolean name
 
-    /// Safely retrieve the named Float[].
+    /// Safely retrieves the named Float[].
     member x.GetFloatArray (name : string) =
         x.TryGetMapArray parseFloat name
 
-    /// Safely retrieve the named Decimal[].
+    /// Safely retrieves the named Decimal[].
     member x.GetDecimalArray (name : string) =
         x.TryGetMapArray parseDecimal name
 
-    /// Safely retrieve the named DateTime[].
+    /// Safely retrieves the named DateTime[].
     member x.GetDateTimeArray (name : string) =
         x.TryGetMapArray parseDateTime name
 
-    /// Safely retrieve the named DateTimeOffset[].
+    /// Safely retrieves the named DateTimeOffset[].
     member x.GetDateTimeOffsetArray (name : string) =
         x.TryGetMapArray parseDateTimeOffset name
 
-    /// Safely retrieve the named Guid[].
+    /// Safely retrieves the named Guid[].
     member x.GetGuidArray (name : string) =
         x.TryGetMapArray parseGuid name
 
-    /// Safely retrieve the named TimeSpan[].
+    /// Safely retrieves the named TimeSpan[].
     member x.GetTimeSpanArray (name : string) =
         x.TryGetMapArray parseTimeSpan name
 
@@ -284,7 +284,7 @@ type FormCollectionReader (form : IFormCollection, files : IFormFileCollection o
     /// Note: Only Some if form enctype="multipart/form-data".
     member _.Files = files
 
-    /// Safely retrieve the named IFormFile option from the IFormFileCollection.
+    /// Safely retrieves the named IFormFile option from the IFormFileCollection.
     member x.TryGetFormFile (name : string) =
         if StringUtils.strEmpty name then None
         else
@@ -303,7 +303,7 @@ type HeaderCollectionReader (headers : IHeaderDictionary) =
         |> Seq.map (fun kvp -> kvp.Key, kvp.Value.ToArray())
         |> Map.ofSeq)
 
-/// Represents a readble collection of query string values.
+/// Represents a readable collection of query string values.
 [<Sealed>]
 type QueryCollectionReader (query : IQueryCollection) =
     inherit StringCollectionReader (
@@ -311,7 +311,7 @@ type QueryCollectionReader (query : IQueryCollection) =
         |> Seq.map (fun kvp -> kvp.Key, kvp.Value.ToArray())
         |> Map.ofSeq)
 
-/// Represents a readble collection of route values.
+/// Represents a readable collection of route values.
 [<Sealed>]
 type RouteCollectionReader (route : RouteValueDictionary, query : IQueryCollection) =
     inherit StringCollectionReader (
@@ -323,7 +323,7 @@ type RouteCollectionReader (route : RouteValueDictionary, query : IQueryCollecti
 
     member _.Query = QueryCollectionReader(query)
 
-/// Represents a readble collection of cookie values.
+/// Represents a readable collection of cookie values.
 [<Sealed>]
 type CookieCollectionReader (cookies: IRequestCookieCollection) =
     inherit StringCollectionReader(


### PR DESCRIPTION
(and little bonus: add a css handler for the hello world sample (`style.css` is referenced but was not served))

The documentation was a bit inconsistent. Sometimes written in the present form as it conventionally should, and sometimes written in the imperative form.