### PR TITLE
Fix jsonOptionsHandler example in response docs

### DIFF
--- a/doc/response.md
+++ b/doc/response.md
@@ -70,7 +70,7 @@ let jsonOptionsHandler : HttpHandler =
     let options = JsonSerializerOptions()
     options.IgnoreNullValues <- true
     let name = { First = "John"; Last = "Doe" }
-    Response.ofJson options name
+    Response.ofJsonOptions options name
 ```
 
 ## Redirect (301/302) Response


### PR DESCRIPTION
Just a very minor thing in the docs, that I came across when using Falco for a side project. 

Apologies for not following the contributor guidelines by opening an issue first, but I _assumed_ that this was small enough that it wouldn't matter too much.

Thanks for this great framework, it's been really fun to work with!